### PR TITLE
fix concatenate

### DIFF
--- a/lizmap_server/tooltip.py
+++ b/lizmap_server/tooltip.py
@@ -208,7 +208,7 @@ class Tooltip:
                     aggregate(
                         layer:='{}',
                         aggregate:='concatenate',
-                        expression:={},
+                        expression:=to_string({}),
                         filter:={}
                     )'''.format(
             layer_id,
@@ -353,7 +353,7 @@ class Tooltip:
                     aggregate(
                         layer:='{}',
                         aggregate:='concatenate',
-                        expression:="{}",
+                        expression:=to_string("{}"),
                         filter:={}
                     )'''.format(
                                 vlid,


### PR DESCRIPTION
<!---
PUT "dev" branch for any new features or next Lizmap version
PUT "master" for bug fix
-->

* **Funded by**: Faunalia
* **Description**: 
  * QGIS concatenate aggregation expression is not working with numeric fields, therefore with need to force a string conversion when creating the tooltip

ref https://github.com/3liz/lizmap-plugin/issues/501 and https://github.com/3liz/lizmap-plugin/pull/502
